### PR TITLE
Upgrade cozo

### DIFF
--- a/native/cozodb/Cargo.lock
+++ b/native/cozodb/Cargo.lock
@@ -424,7 +424,7 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 [[package]]
 name = "cozo"
 version = "0.7.6"
-source = "git+https://github.com/aramallo/cozo.git?tag=augoor-1.4#1259d9e25ee4cc8d26cc7236305729bd57cbfd68"
+source = "git+https://github.com/aramallo/cozo.git?tag=augoor-1.6#e1c381d0a218e73aa0af7e1262bd44b2a4e5623c"
 dependencies = [
  "aho-corasick",
  "approx",
@@ -489,7 +489,7 @@ dependencies = [
 [[package]]
 name = "cozorocks"
 version = "0.1.7"
-source = "git+https://github.com/aramallo/cozo.git?tag=augoor-1.4#1259d9e25ee4cc8d26cc7236305729bd57cbfd68"
+source = "git+https://github.com/aramallo/cozo.git?tag=augoor-1.6#e1c381d0a218e73aa0af7e1262bd44b2a4e5623c"
 dependencies = [
  "cc",
  "cxx",

--- a/native/cozodb/Cargo.toml
+++ b/native/cozodb/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib"]
 [dependencies]
 rustler = {version = "0.33.0", features = ["nif_version_2_17"]}
 # cozo = "0.7.6"
-cozo = {git = "https://github.com/aramallo/cozo.git", tag = "augoor-1.4" }
+cozo = {git = "https://github.com/aramallo/cozo.git", tag = "augoor-1.6" }
 uuid = "1.3.3"
 threadpool = "1.8.1"
 once_cell = "1.18.0"


### PR DESCRIPTION
New `cozo` version adds memory limit and timeout to the stack graphs fixed rule.